### PR TITLE
add wkhtmltopdf engine classes

### DIFF
--- a/application/Espo/Resources/i18n/en_US/Settings.json
+++ b/application/Espo/Resources/i18n/en_US/Settings.json
@@ -139,7 +139,8 @@
         "passwordStrengthBothCases": "Password must contain letters of both upper and lower case",
         "auth2FA": "Enable 2-Factor Authentication",
         "auth2FAForced": "Force regular users to set up 2FA",
-        "auth2FAMethodList": "Available 2FA methods"
+        "auth2FAMethodList": "Available 2FA methods",
+        "pdfEngine": "PDF Template Engine"
     },
     "options": {
         "currencyFormat": {

--- a/application/Espo/Resources/layouts/Settings/settings.json
+++ b/application/Espo/Resources/layouts/Settings/settings.json
@@ -4,7 +4,7 @@
         "rows": [
             [{"name": "useCache"}, {"name": "siteUrl"}],
             [{"name": "maintenanceMode"}, {"name": "cronDisabled"}],
-            [{"name": "useWebSocket"}, false]
+            [{"name": "useWebSocket"}, {"name": "pdfEngine"}]
         ]
     },
     {

--- a/application/Espo/Resources/metadata/app/pdfEngines.json
+++ b/application/Espo/Resources/metadata/app/pdfEngines.json
@@ -34,5 +34,11 @@
             "symbol",
             "times"
         ]
+    },
+    "WkPdf": {
+        "implementationClassNameMap": {
+            "entity": "Espo\\Tools\\Pdf\\WkPdf\\WkPdfEntityPrinter",
+            "collection": "Espo\\Tools\\Pdf\\WkPdf\\WkPdfCollectionPrinter"
+        }
     }
 }

--- a/application/Espo/Resources/metadata/entityDefs/Settings.json
+++ b/application/Espo/Resources/metadata/entityDefs/Settings.json
@@ -748,6 +748,14 @@
         "smsProvider": {
             "type": "enum",
             "view": "views/settings/fields/sms-provider"
+        },
+        "pdfEngine": {
+            "type": "enum",
+            "options": [
+                "Tcpdf",
+                "WkPdf"
+            ],
+            "default": "Tcpdf"
         }
     }
 }

--- a/application/Espo/Services/Pdf.php
+++ b/application/Espo/Services/Pdf.php
@@ -86,6 +86,8 @@ class Pdf
 
     private $dataLoaderManager;
 
+    private \Espo\Entities\Preferences $preferences;
+
     public function __construct(
         Config $config,
         EntityManager $entityManager,
@@ -94,7 +96,8 @@ class Pdf
         SelectBuilderFactory $selectBuilderFactory,
         Builder $builder,
         ServiceContainer $serviceContainer,
-        DataLoaderManager $dataLoaderManager
+        DataLoaderManager $dataLoaderManager,
+        \Espo\Entities\Preferences $preferences
     ) {
         $this->config = $config;
         $this->entityManager = $entityManager;
@@ -104,6 +107,7 @@ class Pdf
         $this->builder = $builder;
         $this->serviceContainer = $serviceContainer;
         $this->dataLoaderManager = $dataLoaderManager;
+        $this->preferences = $preferences;
     }
 
     /**
@@ -144,7 +148,7 @@ class Pdf
             }
         }
 
-        $engine = $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
+        $engine = $this->preferences->get('pdfEngine') ?? $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
 
         $templateWrapper = new TemplateWrapper($template);
 
@@ -248,7 +252,7 @@ class Pdf
 
         $templateWrapper = new TemplateWrapper($template);
 
-        $engine = $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
+        $engine = $this->preferences->get('pdfEngine') ?? $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
 
         $printer = $this->builder
             ->setTemplate($templateWrapper)
@@ -399,7 +403,7 @@ class Pdf
 
         $data = $this->dataLoaderManager->load($entity, $params, $data);
 
-        $engine = $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
+        $engine = $this->preferences->get('pdfEngine') ?? $this->config->get('pdfEngine') ?? self::DEFAULT_ENGINE;
 
         $printer = $this->builder
             ->setTemplate($templateWrapper)

--- a/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+
+use Espo\Core\Utils\Config;
+use Espo\Core\Utils\Json;
+use Espo\Core\Htmlizer\TemplateRendererFactory;
+use Espo\Core\Htmlizer\TemplateRenderer;
+
+use Espo\ORM\Entity;
+
+use Espo\Tools\Pdf\Template;
+use Espo\Tools\Pdf\Data;
+use Espo\Tools\Pdf\Params;
+
+class WkEntityProcessor
+{
+    private Config $config;
+    private TemplateRendererFactory $templateRendererFactory;
+
+    public function __construct(Config $config, TemplateRendererFactory $templateRendererFactory)
+    {
+        $this->config = $config;
+        $this->templateRendererFactory = $templateRendererFactory;
+    }
+
+    public function process(WkPdf $pdf, Template $template, Entity $entity, Params $params, Data $data)
+    {
+        $renderer = $this->templateRendererFactory
+            ->create()
+            ->setApplyAcl($params->applyAcl())
+            ->setEntity($entity)
+            ->setData($data->getAdditionalTemplateData());
+        
+
+        $opts = [
+            'orientation' => $template->getPageOrientation(),
+            'margin-bottom' => $template->getBottomMargin(),
+            'margin-top' => $template->getTopMargin(),
+            'margin-left' => $template->getLeftMargin(),
+            'margin-right' => $template->getRightMargin(),
+            'title' => $template->getTitle(),
+        ];
+
+        if($template->getPageFormat() === 'Custom') {
+            $opts['page-width'] = $template->getPageWidth();
+            $opts['page-height'] = $template->getPageHeight();
+        } else {
+            $opts['page-size'] = $template->getPageFormat();
+        }
+
+        $pdf->setOptions($opts);
+
+        $header = tempnam(sys_get_temp_dir(), 'header-tpl');
+        $footer = tempnam(sys_get_temp_dir(), 'footer-tpl');
+
+        if($template->hasHeader()) {
+            file_put_contents($header.'.html', "<!DOCTYPE html><html>".$renderer->renderTemplate($template->getHeader())."</html>");
+            $pdf->setOptions([
+                'header-html' => $header.'.html'
+            ]);
+        }
+
+        if($template->hasFooter()) {
+            file_put_contents($footer.'.html', "<!DOCTYPE html><html>".$renderer->renderTemplate($template->getFooter())."</html>");
+            $pdf->setOptions([
+                'footer-html' => $footer.'.html'
+            ]);
+        }
+        
+        $htmlBody = $renderer->renderTemplate($template->getBody());
+        $pdf->addPage($htmlBody);
+
+        unlink($header);
+        unlink($footer);
+    }
+}

--- a/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+namespace Espo\Tools\Pdf\WkPdf;
 
 use Espo\Core\Utils\Config;
 use Espo\Core\Utils\Json;

--- a/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkEntityProcessor.php
@@ -15,16 +15,14 @@ use Espo\Tools\Pdf\Params;
 
 class WkEntityProcessor
 {
-    private Config $config;
     private TemplateRendererFactory $templateRendererFactory;
 
-    public function __construct(Config $config, TemplateRendererFactory $templateRendererFactory)
+    public function __construct(TemplateRendererFactory $templateRendererFactory)
     {
-        $this->config = $config;
         $this->templateRendererFactory = $templateRendererFactory;
     }
 
-    public function process(WkPdf $pdf, Template $template, Entity $entity, Params $params, Data $data)
+    public function process(WkPdf $pdf, Template $template, Entity $entity, Params $params, Data $data) : void
     {
         $renderer = $this->templateRendererFactory
             ->create()
@@ -51,9 +49,9 @@ class WkEntityProcessor
 
         $pdf->setOptions($opts);
 
-        $header = tempnam(sys_get_temp_dir(), 'header-tpl');
-        $footer = tempnam(sys_get_temp_dir(), 'footer-tpl');
-
+        $header = (string)tempnam(sys_get_temp_dir(), 'header-tpl');
+        $footer = (string)tempnam(sys_get_temp_dir(), 'footer-tpl');
+        
         if($template->hasHeader()) {
             file_put_contents($header.'.html', "<!DOCTYPE html><html>".$renderer->renderTemplate($template->getHeader())."</html>");
             $pdf->setOptions([

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
@@ -1,5 +1,5 @@
 <?php
-namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+namespace Espo\Tools\Pdf\WkPdf;
 
 use mikehaertl\wkhtmlto\Pdf;
 

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
@@ -1,0 +1,9 @@
+<?php
+namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+
+use mikehaertl\wkhtmlto\Pdf;
+
+class WkPdf extends Pdf
+{
+    public $binary = "/wkhtmltopdf";
+}

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdf.php
@@ -5,5 +5,5 @@ use mikehaertl\wkhtmlto\Pdf;
 
 class WkPdf extends Pdf
 {
-    public $binary = "/wkhtmltopdf";
+    public $binary = "wkhtmltopdf";
 }

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfCollectionPrinter.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfCollectionPrinter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+
+use Espo\ORM\Collection;
+use Espo\Tools\Pdf\CollectionPrinter;
+use Espo\Tools\Pdf\Template;
+use Espo\Tools\Pdf\Contents;
+use Espo\Tools\Pdf\Data;
+use Espo\Tools\Pdf\IdDataMap;
+use Espo\Tools\Pdf\Params;
+
+class WkPdfCollectionPrinter implements CollectionPrinter
+{
+    private WkEntityProcessor $entityProcessor;
+
+    public function __construct(WkEntityProcessor $entityProcessor)
+    {
+        $this->entityProcessor = $entityProcessor;
+    }
+
+    public function print(Template $template, Collection $collection, Params $params, IdDataMap $dataMap): Contents
+    {
+        $pdf = new WkPdf();
+
+        foreach($collection as $entity) {
+            $data = $dataMap->get($entity->getId()) ?? Data::create();
+
+            $this->entityProcessor->process($pdf, $template, $entity, $params, $data);
+        }
+
+        return new WkPdfContents($pdf);
+    }
+}

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfCollectionPrinter.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfCollectionPrinter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+namespace Espo\Tools\Pdf\WkPdf;
 
 use Espo\ORM\Collection;
 use Espo\Tools\Pdf\CollectionPrinter;

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+namespace Espo\Tools\Pdf\WkPdf;
 
 use mikehaertl\wkhtmlto\Pdf as WkPdf;
 use Espo\Tools\Pdf\Contents;

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
@@ -34,7 +34,7 @@ class WkPdfContents implements Contents
 
     public function getString(): string
     {
-        return $this->pdf->toString();
+        return (string)$this->pdf->toString();
     }
 
     public function getLength(): int

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfContents.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+
+use mikehaertl\wkhtmlto\Pdf as WkPdf;
+use Espo\Tools\Pdf\Contents;
+use Psr\Http\Message\StreamInterface;
+use GuzzleHttp\Psr7\Stream;
+
+use RuntimeException;
+
+class WkPdfContents implements Contents
+{
+    private $pdf;
+
+    public function __construct(WkPdf $pdf)
+    {
+        $this->pdf = $pdf;
+    }
+
+    public function getStream(): StreamInterface
+    {
+        $resource = fopen('php://temp', 'r+');
+
+        if ($resource === false) {
+            throw new RuntimeException("Could not open temp.");
+        }
+
+        fwrite($resource, $this->getString());
+        rewind($resource);
+
+        return new Stream($resource);
+    }
+
+    public function getString(): string
+    {
+        return $this->pdf->toString();
+    }
+
+    public function getLength(): int
+    {
+        return strlen($this->getString());
+    }
+}

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+namespace Espo\Tools\Pdf\WkPdf;
 
 use Espo\ORM\Entity;
 use Espo\Tools\Pdf\EntityPrinter;

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Espo\Modules\Academy\Tools\Pdf\WkPdf;
+
+use Espo\ORM\Entity;
+use Espo\Tools\Pdf\EntityPrinter;
+use Espo\Tools\Pdf\Template;
+use Espo\Tools\Pdf\Contents;
+use Espo\Tools\Pdf\Params;
+use Espo\Tools\Pdf\Data;
+
+class WkPdfEntityPrinter implements EntityPrinter
+{
+    protected $entityProcessor;
+
+    public function __construct(WkEntityProcessor $entityProcessor)
+    {
+        $this->entityProcessor = $entityProcessor;
+    }
+
+    public function print(Template $template, Entity $entity, Params $params, Data $data) : Contents
+    {
+        $pdf = new WkPdf();
+
+        $this->entityProcessor->process($pdf, $template, $entity, $params, $data);
+
+        return new WkPdfContents($pdf);
+    }
+}

--- a/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
+++ b/application/Espo/Tools/Pdf/WkPdf/WkPdfEntityPrinter.php
@@ -11,7 +11,7 @@ use Espo\Tools\Pdf\Data;
 
 class WkPdfEntityPrinter implements EntityPrinter
 {
-    protected $entityProcessor;
+    protected WkEntityProcessor $entityProcessor;
 
     public function __construct(WkEntityProcessor $entityProcessor)
     {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "doctrine/dbal": "^3.3.3",
         "league/flysystem-async-aws-s3": "^2.0",
         "johngrogg/ics-parser": "^3.0",
-        "laminas/laminas-zendframework-bridge": "^1.4"
+        "laminas/laminas-zendframework-bridge": "^1.4",
+        "mikehaertl/phpwkhtmltopdf": "^2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e703473276c8dc1f630d38a0bf3c9ac9",
+    "content-hash": "cd623dd1518b0eb56c4cb3d79999109e",
     "packages": [
         {
             "name": "async-aws/core",
@@ -2113,6 +2113,147 @@
                 "source": "https://github.com/michelf/php-markdown/tree/1.9.0"
             },
             "time": "2019-12-02T02:32:27+00:00"
+        },
+        {
+            "name": "mikehaertl/php-shellcommand",
+            "version": "1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/php-shellcommand.git",
+                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/php-shellcommand/zipball/3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "reference": "3488d7803df1e8f1a343d3d0ca452d527ad8d5e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">4.0 <=9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\shellcommand\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Härtl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "An object oriented interface to shell commands",
+            "keywords": [
+                "shell"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/php-shellcommand/issues",
+                "source": "https://github.com/mikehaertl/php-shellcommand/tree/1.6.4"
+            },
+            "time": "2021-03-17T06:54:33+00:00"
+        },
+        {
+            "name": "mikehaertl/php-tmpfile",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/php-tmpfile.git",
+                "reference": "70a5b70b17bc0d9666388e6a551ecc93d0b40a10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/php-tmpfile/zipball/70a5b70b17bc0d9666388e6a551ecc93d0b40a10",
+                "reference": "70a5b70b17bc0d9666388e6a551ecc93d0b40a10",
+                "shasum": ""
+            },
+            "require-dev": {
+                "php": ">=5.3.0",
+                "phpunit/phpunit": ">4.0 <=9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\tmp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Härtl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "A convenience class for temporary files",
+            "keywords": [
+                "files"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/php-tmpfile/issues",
+                "source": "https://github.com/mikehaertl/php-tmpfile/tree/1.2.1"
+            },
+            "time": "2021-03-01T18:26:25+00:00"
+        },
+        {
+            "name": "mikehaertl/phpwkhtmltopdf",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mikehaertl/phpwkhtmltopdf.git",
+                "reference": "17ee71341591415d942774eda2c98d8ba7ea9e90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mikehaertl/phpwkhtmltopdf/zipball/17ee71341591415d942774eda2c98d8ba7ea9e90",
+                "reference": "17ee71341591415d942774eda2c98d8ba7ea9e90",
+                "shasum": ""
+            },
+            "require": {
+                "mikehaertl/php-shellcommand": "^1.5.0",
+                "mikehaertl/php-tmpfile": "^1.2.1",
+                "php": ">=5.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">4.0 <9.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "mikehaertl\\wkhtmlto\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Haertl",
+                    "email": "haertl.mike@gmail.com"
+                }
+            ],
+            "description": "A slim PHP wrapper around wkhtmltopdf with an easy to use and clean OOP interface",
+            "homepage": "http://mikehaertl.github.com/phpwkhtmltopdf/",
+            "keywords": [
+                "pdf",
+                "wkhtmltoimage",
+                "wkhtmltopdf"
+            ],
+            "support": {
+                "issues": "https://github.com/mikehaertl/phpwkhtmltopdf/issues",
+                "source": "https://github.com/mikehaertl/phpwkhtmltopdf/tree/2.5.0"
+            },
+            "time": "2021-03-01T19:41:06+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -7637,7 +7778,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4.0",
+        "php": ">=7.4.0 <8.2.0",
         "ext-pdo_mysql": "*",
         "ext-openssl": "*",
         "ext-json": "*",
@@ -7646,8 +7787,9 @@
         "ext-mbstring": "*",
         "ext-xml": "*",
         "ext-curl": "*",
-        "ext-exif": "*"
+        "ext-exif": "*",
+        "ext-pdo": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
Add integration for printing PDF files with [wkhtmltopdf](https://wkhtmltopdf.org/).

## motivation

The current default PDF engine Tcpdf is very limited but probably the best fit with *native* php frameworks (as stated in [this discussion](https://forum.espocrm.com/forum/feature-requests/64836-pdf-template-generation/)).
However, there are open-source alternatives which are wrappers like headless chromium and wkhtmltopdf.

I think it would be a great enhancement to support more pdf engines and be able to select between them. I decided to begin with wkhtmltopdf since it is very leightweight, cross-platform and works well with modern HTML/CSS. 

## usage

- install wkhtmltopdf
- change `pdfEngine` to `WkPdf` in `config.php`

## issues / pending features

1. [ ] add configuration option for wkhtmltopdf binary path
1. [ ] adjust WkEntityPrinter to support all config options that Tcpdf does