### PR TITLE
docker stack for local development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PODMAN_USERNS=keep-id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+
+  mysql:
+    image: mysql:8
+    container_name: mysql
+    command: --default-authentication-plugin=mysql_native_password    
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: espocrm
+      MYSQL_USER: espocrm
+      MYSQL_PASSWORD: espocrm
+    volumes:
+      - mysql:/var/lib/mysql
+    restart: always
+    ports:
+      - 3306:3306
+
+  espocrm:
+    image: webdevops/php-apache:8.0
+    #image: espodev
+    #build:
+    #  context: ./docker
+    #  dockerfile: Dockerfile.dev
+    container_name: espocrm
+    environment:
+      ESPOCRM_DATABASE_HOST: localhost
+      ESPOCRM_DATABASE_USER: espocrm
+      ESPOCRM_DATABASE_PASSWORD: database_password
+      ESPOCRM_ADMIN_USERNAME: admin
+      ESPOCRM_ADMIN_PASSWORD: password
+      ESPOCRM_SITE_URL: "http://localhost:8080"
+    volumes:
+      - ./build/EspoCRM-7.1.9:/app
+      - ./home/superewald/Downloads/wkhtmltopdf/usr/local/bin/wkhtmltopdf:/usr/bin/wkhtmltopdf
+    restart: always
+    ports:
+      - 8080:80
+
+volumes:
+  mysql:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       ESPOCRM_ADMIN_PASSWORD: admin
       ESPOCRM_SITE_URL: "http://localhost:8080"
     volumes:
-      - ./build/EspoCRM-7.1.9:/app
+      - ./:/app
     restart: always
     ports:
       - 8080:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   mysql:
     image: mysql:8
-    container_name: mysql
+    container_name: espo-db
     command: --default-authentication-plugin=mysql_native_password    
     environment:
       MYSQL_ROOT_PASSWORD: root_password
@@ -18,22 +18,20 @@ services:
       - 3306:3306
 
   espocrm:
-    image: webdevops/php-apache:8.0
-    #image: espodev
-    #build:
-    #  context: ./docker
-    #  dockerfile: Dockerfile.dev
-    container_name: espocrm
+    image: espodev
+    build:
+      context: ./docker
+      dockerfile: Dockerfile.dev
+    container_name: espo-dev
     environment:
-      ESPOCRM_DATABASE_HOST: localhost
+      ESPOCRM_DATABASE_HOST: mysql
       ESPOCRM_DATABASE_USER: espocrm
-      ESPOCRM_DATABASE_PASSWORD: database_password
+      ESPOCRM_DATABASE_PASSWORD: espocrm
       ESPOCRM_ADMIN_USERNAME: admin
-      ESPOCRM_ADMIN_PASSWORD: password
+      ESPOCRM_ADMIN_PASSWORD: admin
       ESPOCRM_SITE_URL: "http://localhost:8080"
     volumes:
       - ./build/EspoCRM-7.1.9:/app
-      - ./home/superewald/Downloads/wkhtmltopdf/usr/local/bin/wkhtmltopdf:/usr/bin/wkhtmltopdf
     restart: always
     ports:
       - 8080:80

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM webdevops/php-apache:8.0
+
+ARG NODE_VERSION=16.16.0
+
+# install nodejs, npm, grunt
+RUN export NODE_VER=$(curl -s https://nodejs.org/en/ | grep -Po '\d*\.\d*\.\d* LTS' | head -n1 | cut -f1 -d' ') && \
+    curl https://nodejs.org/dist/v$NODE_VER/node-v$NODE_VER-linux-x64.tar.xz    | tar --file=- --extract --xz --directory /usr/local/ --strip-components=1 && \
+    npm install -g grunt-cli

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,3 +6,11 @@ ARG NODE_VERSION=16.16.0
 RUN export NODE_VER=$(curl -s https://nodejs.org/en/ | grep -Po '\d*\.\d*\.\d* LTS' | head -n1 | cut -f1 -d' ') && \
     curl https://nodejs.org/dist/v$NODE_VER/node-v$NODE_VER-linux-x64.tar.xz    | tar --file=- --extract --xz --directory /usr/local/ --strip-components=1 && \
     npm install -g grunt-cli
+
+# install wkhtmltopdf
+RUN apt update && apt install -y wkhtmltopdf
+
+# configure crontab
+COPY ./espo-cron /etc/cron.d/espo-cron
+RUN chmod 0644 /etc/cron.d/espo-cron && \
+    crontab /etc/cron.d/espo-cron

--- a/docker/espo-cron
+++ b/docker/espo-cron
@@ -1,0 +1,1 @@
+* * * * * cd /app; /usr/local/bin/php -f cron.php > /dev/null 2>&1


### PR DESCRIPTION
This PR adds a simple local containerized development stack for local development.

## motivation

Containers are extremely useful for local development in my opinion and reduces the headaches setting up a local development environment, thus increasing development experience drasticaly.

## summary

There is a simple `docker-compose.yml` which includes all basic services ([mysql](https://hub.docker.com/_/mysql), espocrm based on [webdevops/php-apache:8.0](https://dockerfile.readthedocs.io/en/latest/content/DockerImages/dockerfiles/php-apache.html)) to run a local environment. 

The `docker-compose.yml` creates a new image `espodev` which includes dependencies and configuration for EspoCRM.

> I personally recommend and use podman instead of docker, the scripts provided here require podman >= 4.0 and podman-compose from devel branch!

## usage

- (**required only before first run**) build the `espodev` image: `docker-compose build`
- build espocrm (`espodev` mounts `build/EspoCRM-${VERSION}`) : `grunt build`
- start service stack: `docker-compose up -d`
- browse to [localhost:8080](http://localhost:8080)

## issues / pending features

1. [ ] running `grunt build` while running containers will invalidate the `build/EspoCRM-...` mount because the directory is deleted while building
    > Instead of mounting the build directory itself rather mount the root directory and run build scripts inside the container using grunt watchers.
1. [ ] add a default config file to skip install step of EspoCRM
1. [ ] add workflow to install/update local builds of extensions (this ensures extensions can be tested against different versions without running espocrm for every extension)